### PR TITLE
Migrations fields not needed as inherited by _concept

### DIFF
--- a/aristotle_glossary/migrations/0001_initial.py
+++ b/aristotle_glossary/migrations/0001_initial.py
@@ -26,16 +26,7 @@ class Migration(migrations.Migration):
             name='GlossaryItem',
             fields=[
                 ('_concept_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='aristotle_mdr._concept')),
-                ('short_name', models.CharField(max_length=100, blank=True)),
-                ('version', models.CharField(max_length=20, blank=True)),
-                ('synonyms', models.CharField(max_length=200, blank=True)),
-                ('references', ckeditor.fields.RichTextField(blank=True)),
-                ('origin_URI', models.URLField(help_text='If imported, the original location of the item', blank=True)),
-                ('comments', ckeditor.fields.RichTextField(help_text='Descriptive comments about the metadata item.', blank=True)),
-                ('submitting_organisation', models.CharField(max_length=256, blank=True)),
-                ('responsible_organisation', models.CharField(max_length=256, blank=True)),
                 ('index', models.ManyToManyField(related_name='related_glossary_items', null=True, to='aristotle_mdr._concept', blank=True)),
-                ('superseded_by', models.ForeignKey(related_name='supersedes', blank=True, to='aristotle_glossary.GlossaryItem', null=True)),
             ],
             options={
                 'abstract': False,


### PR DESCRIPTION
Removed from the GlossaryItem model creation uneccesary fieds as these were inherited from _concept model.